### PR TITLE
UnionFind optimization

### DIFF
--- a/kruskals_union_set.rb
+++ b/kruskals_union_set.rb
@@ -1,5 +1,5 @@
 #Kruskal's algorithm
-def header 
+def header
   @header ||= file.take(1)[0]
 end
 
@@ -7,7 +7,7 @@ def number_of_nodes
   @number_of_nodes ||= header.split(" ")[0].to_i
 end
 
-def file 
+def file
   @file ||= File.readlines("edges.txt")
 end
 
@@ -16,11 +16,11 @@ class UnionFind
   def initialize(n)
     @leaders = 1.upto(n).inject([]) { |leaders, i| leaders[i] = i; leaders }
   end
-  
+
   def connected?(id1,id2)
     @leaders[id1] == @leaders[id2]
   end
-  
+
   def union(id1,id2)
     leader_1, leader_2 = @leaders[id1], @leaders[id2]
     @leaders.map! {|i| (i == leader_1) ? leader_2 : i }
@@ -34,12 +34,12 @@ set = UnionFind.new number_of_nodes
 edges = file.drop(1).map { |x| x.gsub(/\n/, "").split(" ").map(&:to_i) }.
                      map { |one, two, weight| { :from => one, :to => two, :weight => weight}}.
                      sort_by { |x| x[:weight]}
-                     
+
 edges.each do |edge|
   if !set.connected?(edge[:from], edge[:to])
-    @minimum_spanning_tree << edge 
+    @minimum_spanning_tree << edge
     set.union(edge[:from], edge[:to])
-  end  
+  end
 end
 
 puts "MST: #{@minimum_spanning_tree}"

--- a/kruskals_union_set.rb
+++ b/kruskals_union_set.rb
@@ -14,18 +14,18 @@ end
 # Some renaming of variables of Michael Luckender's class -> https://github.com/mluckeneder/Union-Find-Ruby/blob/master/quick-union.rb
 class UnionFind
   def initialize(n)
-    @leaders = Hash.new{|subsets, element| subsets[element] = [element]}
+    @subsets = Hash.new{|subsets, element| subsets[element] = [element]}
   end
 
   def connected?(id1,id2)
-    @leaders[id1] == @leaders[id2]
+    @subsets[id1] == @subsets[id2]
   end
 
   def union(id1,id2)
-    leader_1, leader_2 = @leaders[id1], @leaders[id2]
-    leader_1.each do |element, _|
-      @leaders[element] = leader_2 << element
-    end unless leader_1 == leader_2
+    subset_1, subset_2 = @subsets[id1], @subsets[id2]
+    subset_1.each do |element, _|
+      @subsets[element] = subset_2 << element
+    end unless subset_1 == subset_2
   end
 end
 

--- a/kruskals_union_set.rb
+++ b/kruskals_union_set.rb
@@ -14,7 +14,7 @@ end
 # Some renaming of variables of Michael Luckender's class -> https://github.com/mluckeneder/Union-Find-Ruby/blob/master/quick-union.rb
 class UnionFind
   def initialize(n)
-    @leaders = 1.upto(n).inject([]) { |leaders, i| leaders[i] = i; leaders }
+    @leaders = Hash.new{|subsets, element| subsets[element] = [element]}
   end
 
   def connected?(id1,id2)
@@ -23,7 +23,9 @@ class UnionFind
 
   def union(id1,id2)
     leader_1, leader_2 = @leaders[id1], @leaders[id2]
-    @leaders.map! {|i| (i == leader_1) ? leader_2 : i }
+    leader_1.each do |element, _|
+      @leaders[element] = leader_2 << element
+    end unless leader_1 == leader_2
   end
 end
 

--- a/kruskals_union_set.rb
+++ b/kruskals_union_set.rb
@@ -13,7 +13,7 @@ end
 
 # Some renaming of variables of Michael Luckender's class -> https://github.com/mluckeneder/Union-Find-Ruby/blob/master/quick-union.rb
 class UnionFind
-  def initialize(n)
+  def initialize
     @subsets = Hash.new{|subsets, element| subsets[element] = [element]}
   end
 
@@ -29,7 +29,7 @@ class UnionFind
   end
 end
 
-set = UnionFind.new number_of_nodes
+set = UnionFind.new
 
 @minimum_spanning_tree = []
 


### PR DESCRIPTION
I realize this project is a soltion for a course that ran some years ago, but...

While [answering a question](http://unix.stackexchange.com/a/163152/57441) on unix.stackexchange I have wondered if there a ruby implementation of disjoint set existed and came across your [blog post](http://ruby.dzone.com/articles/algorithm-week-kruskal%E2%80%99s) about the implementation of Kruskal algorithm using UnionFind. I had a look at the code and realized that it could be even more efficient. So for the sake of the next person googling for disjoint-set / union-find in ruby I am making this pull request :-)

The key differences are:
1. `UnionFind` maintains a hash of subsets, not just subset leaders. Each subset is an array, shared among its members (so if we have a disjoint set `[1 2] [3]` the corresponding hash could look like `{1 => [1, 2], 2 => [1, 2], 3 => [3]}`, where two `[1, 2]`s are the same array object.
2. When joining two subsets it isn't necessary to iterate over the whole disjoint set as we have the list of elements whose subset is about to change right away. This is the "more efficient" part. It starts making a difference when the structure is sufficiently large. 
3. The constructor doesn't prepopulate the structure with singleton subsets, instead it uses Hash constructor with a block, which adds and returns a singleton subset if element isn't in the disjoint set yet. Since the original structure didn't provide the means to query lengthor to iterate over itself, nothing really broke. As a side effect the structure isn't limited to containing natural numbers, it can contain pretty much anything. Constructor doesn't accept size anymore.

I've compared the output of the modified solution against the original and they are identical, looks like I haven't broken anything.
